### PR TITLE
Move from IRC to Rocket, AskUbuntu to Stack Overflow

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -7,9 +7,7 @@ layout: default
         <div class="eight-col">
             <h1 class="hero-row__heading">Community and support</h1>
             <p>Whether you want to snap your own app or an established open source
-            application, you’ll find plenty of help here. Joining the growing
-            community of Snappy developers is as simple as signing up to a <a class="external" href="https://lists.snapcraft.io/mailman/listinfo/snapcraft">mailing
-            list</a> or have some fun in the <a class="external" href="https://github.com/ubuntu/snappy-playpen">Snappy Playpen.</a></p>
+            application, you’ll find plenty of help here.</p>
             <p>Interacting with the Snappy community can be useful in other ways
             too. It can help you attract new users for your app, and it can be a
             great way to start contributing to the platform’s most popular projects.</p>
@@ -24,18 +22,18 @@ layout: default
             <div class="equal-height--vertical-divider">
 
                 <div class="six-col box">
-                    <h3><a href="http://askubuntu.com/questions/tagged/snap">Got a question? AskUbuntu ›</a></h3>
+                    <h3><a href="http://stackoverflow.com/questions/ask?tags=snapcraft">Got a question? Ask on Stack Overflow ›</a></h3>
                     <p>If you’re stuck, the chances are that someone else has encountered
                     the same problem and they can help. Take a look at the
-                    <a class="external" href="http://askubuntu.com/questions/tagged/snap">"snap" tag</a>
-                    on AskUbuntu.</p>
+                    <a class="external" href="http://stackoverflow.com/questions/tagged/snapcraft">"snapcraft" tag</a>
+                    on Stack Overflow.</p>
                 </div>
 
                 <div class="six-col last-col box">
-                    <h3><a href="https://webchat.freenode.net/?channels=snappy">Or chat in real time ›</a></h3>
+                    <h3><a href="https://rocket.ubuntu.com/channel/snapcraft">Or chat in real time ›</a></h3>
                     <p>Share your projects and ask other developers for support. This
-                    high-bandwidth IRC channel is a great place to find <a class="external"
-                    href="https://webchat.freenode.net/?channels=snappy">a quick answer</a>
+                    high-bandwidth chat room is a great place to find <a class="external"
+                    href="https://rocket.ubuntu.com/channel/snapcraft">a quick answer</a>
                     to a single question.</p>
                 </div>
 


### PR DESCRIPTION
AskUbuntu is unsurprisingly Ubuntu-branded and Snapcraft is a cross-distribution effort. Stack Overflow is brand-neutral and has a much larger, broader audience than AskUbuntu.

rocket.ubuntu.com is more active than the freenode IRC channel.